### PR TITLE
[CRM457-2282] add main_offence_type to schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa_crime_forms_common (0.5.2)
+    laa_crime_forms_common (0.5.3)
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)

--- a/lib/laa_crime_forms_common/version.rb
+++ b/lib/laa_crime_forms_common/version.rb
@@ -1,3 +1,3 @@
 module LaaCrimeFormsCommon
-  VERSION = "0.5.2".freeze
+  VERSION = "0.5.3".freeze
 end

--- a/lib/schemas/nsm/v1.json
+++ b/lib/schemas/nsm/v1.json
@@ -1271,6 +1271,15 @@
       "x-pii": false,
       "type":"string"
     },
+    "main_offence_type":{
+      "examples":[
+        "summary_only"
+      ],
+      "title":"What is the offence type?",
+      "x-pii": false,
+      "type":["string", "null"],
+      "enum":["summary_only", "either_way", "indictable_only", "prescribed_proceedings"]
+    },
     "main_offence_date":{
       "examples":[
         "2012-12-12"
@@ -2245,6 +2254,7 @@
         }
       ],
       "main_offence":"asdasdasdasd",
+      "main_offence_type":"asdasdasdasd",
       "main_offence_date":"2012-12-12",
       "matter_type":"2",
       "number_of_hearing":12,


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2282)

## Notes for reviewer

Is this a patch or minor version bump (as its changing schema)? 

## How to manually test the feature
