### PR TITLE
CRM457-2298 (pt 1): Remove unrequired fields from cost_summary part of payload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa_crime_forms_common (0.6.0)
+    laa_crime_forms_common (0.6.1)
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)

--- a/lib/laa_crime_forms_common/version.rb
+++ b/lib/laa_crime_forms_common/version.rb
@@ -1,3 +1,3 @@
 module LaaCrimeFormsCommon
-  VERSION = "0.6.0".freeze
+  VERSION = "0.6.1".freeze
 end

--- a/lib/schemas/nsm/v1.json
+++ b/lib/schemas/nsm/v1.json
@@ -399,12 +399,7 @@
           "type":"object"
         }
       },
-      "required":[
-        "disbursements",
-        "profit_costs",
-        "travel",
-        "waiting"
-      ],
+      "required":[],
       "title":"Cost summary",
       "type":"object"
     },


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2298)

## Notes for reviewer
Since we now use the LAA Crime Forms Common gem to get things we used to get from the cost summary, these fields are no longer compulsory

## How to manually test the feature
