### PR TITLE
CRM457-2277: Standardised mechanism for S3 downloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa_crime_forms_common (0.7.2)
+    laa_crime_forms_common (0.8.0)
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)

--- a/lib/laa_crime_forms_common.rb
+++ b/lib/laa_crime_forms_common.rb
@@ -4,9 +4,10 @@ require "laa_crime_forms_common/anonymiser"
 require "laa_crime_forms_common/assignment"
 require "laa_crime_forms_common/autogrant/prior_authority"
 require "laa_crime_forms_common/hooks"
-require "laa_crime_forms_common/pricing/nsm"
-require "laa_crime_forms_common/validator"
 require "laa_crime_forms_common/messages/prior_authority"
+require "laa_crime_forms_common/pricing/nsm"
+require "laa_crime_forms_common/s3_files"
+require "laa_crime_forms_common/validator"
 
 mydir = __dir__
 I18n.load_path += Dir[File.join(mydir, "locales", "**/*.yml")]

--- a/lib/laa_crime_forms_common/s3_files.rb
+++ b/lib/laa_crime_forms_common/s3_files.rb
@@ -1,0 +1,23 @@
+require "uri"
+
+# This class exists to generate user-friendly, temporary download URLs for
+# files stored in S3. Specifically it handled:
+# - Making sure the files expire
+# - Making sure that the file is downloaded by the browser
+# - Making sure that the filename of the downloaded file is valid
+
+# It assumes that s3_bucket is an appropriately configured Aws::S3::Bucket object
+module LaaCrimeFormsCommon
+  class S3Files
+    PRESIGNED_EXPIRY = 60
+
+    def self.temporary_download_url(s3_bucket, file_key, original_file_name)
+      escaped = URI.encode_uri_component(original_file_name)
+      response_content_disposition = "attachment; filename=\"#{escaped}\"; filename*=UTF-8''#{escaped}"
+      s3_bucket.object(file_key)
+               .presigned_url(:get,
+                              expires_in: PRESIGNED_EXPIRY,
+                              response_content_disposition:)
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/version.rb
+++ b/lib/laa_crime_forms_common/version.rb
@@ -1,3 +1,3 @@
 module LaaCrimeFormsCommon
-  VERSION = "0.7.2".freeze
+  VERSION = "0.8.0".freeze
 end

--- a/spec/s3_files_spec.rb
+++ b/spec/s3_files_spec.rb
@@ -1,0 +1,71 @@
+require_relative "../lib/laa_crime_forms_common/s3_files"
+require "spec_helper"
+
+RSpec.describe LaaCrimeFormsCommon::S3Files do
+  describe ".temporary_download_url" do
+    subject { described_class.temporary_download_url(s3_bucket, file_path, original_file_name) }
+    let(:s3_bucket) { double(:s3_bucket) }
+    let(:s3_object) { double(:s3_object) }
+    let(:generated_url) { "GENERATED_URL" }
+    let(:file_path) { "FILE_PATH" }
+    let(:original_file_name) { "ORIGINAL_FILE_NAME.jpg" }
+
+    before do
+      allow(s3_bucket).to receive(:object).and_return(s3_object)
+      allow(s3_object).to receive(:presigned_url).and_return(generated_url)
+    end
+
+    it "calls the appropriate AWS methods" do
+      subject
+      expect(s3_bucket).to have_received(:object).with(file_path)
+      expect(s3_object).to have_received(:presigned_url).with(
+        :get,
+        expires_in: 60,
+        response_content_disposition: "attachment; filename=\"#{original_file_name}\"; filename*=UTF-8''#{original_file_name}",
+      )
+    end
+
+    it "returns the generated url" do
+      expect(subject).to eq generated_url
+    end
+
+    context "when the file name has an unusual character in it" do
+      let(:original_file_name) { "the–first-dash-in-this-file-name-is-an-unusual-one.pdf'" }
+
+      it "escapes appropriately" do
+        subject
+        expect(s3_object).to have_received(:presigned_url).with(
+          :get,
+          expires_in: 60,
+          response_content_disposition: "attachment; filename=\"the%E2%80%93first-dash-in-this-file-name-is-an-unusual-one.pdf%27\"; filename*=UTF-8''the%E2%80%93first-dash-in-this-file-name-is-an-unusual-one.pdf%27",
+        )
+      end
+    end
+
+    context "when the file name has a double quote in it" do
+      let(:original_file_name) { 'file-with-"double-quotes".pdf' }
+
+      it "escapes appropriately" do
+        subject
+        expect(s3_object).to have_received(:presigned_url).with(
+          :get,
+          expires_in: 60,
+          response_content_disposition: "attachment; filename=\"file-with-%22double-quotes%22.pdf\"; filename*=UTF-8''file-with-%22double-quotes%22.pdf",
+        )
+      end
+    end
+
+    context "when the file name has spaces in it" do
+      let(:original_file_name) { "file with spaces.pdf" }
+
+      it "escapes appropriately" do
+        subject
+        expect(s3_object).to have_received(:presigned_url).with(
+          :get,
+          expires_in: 60,
+          response_content_disposition: "attachment; filename=\"file%20with%20spaces.pdf\"; filename*=UTF-8''file%20with%20spaces.pdf",
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Provider and caseworker need to allow downloads of S3 files, and the logic is quite fiddly, so I've moved it into the gem so we only need to write it once.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-277)

## Notes for reviewer
(This does what the apps currently do just with more comprehensive filename escaping)
