### PR TITLE
CRM457-2403: Update last_updated_at field when Submission has had Provider Updated event 

### DIFF
--- a/lib/laa_crime_forms_common/hooks.rb
+++ b/lib/laa_crime_forms_common/hooks.rb
@@ -19,9 +19,12 @@ module LaaCrimeFormsCommon
     end
 
     def submission_updated(submission, now)
-      return unless submission.state == "provider_updated" && submission.application_type == "crm7"
-
-      add_new_version_event(submission, now)
+      if submission.state == "provider_updated"
+        submission.last_updated_at = now
+        if submission.application_type == "crm7"
+          add_new_version_event(submission, now)
+        end
+      end
     end
 
   private

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe LaaCrimeFormsCommon::Hooks do
            application_type:,
            latest_version:,
            events: [],
+           'last_updated_at=': :now,
            'application_risk=': true)
   end
   let(:latest_version) do
@@ -179,6 +180,11 @@ RSpec.describe LaaCrimeFormsCommon::Hooks do
         public: false,
         does_not_constitute_update: false,
       )
+    end
+
+    it "updates submission last_updated_at" do
+      described_class.submission_updated(submission, now)
+      expect(submission).to have_received("last_updated_at=").with(:now).once
     end
 
     context "when not crm7" do


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2403)

- Always updates last_updated_at via submission_updated hook

## Notes for reviewer

## How to manually test the feature
