### PR TITLE
[CRM457-1792] add optional gdpr_documents_deleted flag for nsm

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa_crime_forms_common (0.9.0)
+    laa_crime_forms_common (0.9.1)
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)

--- a/lib/laa_crime_forms_common/version.rb
+++ b/lib/laa_crime_forms_common/version.rb
@@ -1,3 +1,3 @@
 module LaaCrimeFormsCommon
-  VERSION = "0.9.0".freeze
+  VERSION = "0.9.1".freeze
 end

--- a/lib/schemas/nsm/v1.json
+++ b/lib/schemas/nsm/v1.json
@@ -1073,6 +1073,14 @@
         ]
       ]
     },
+    "gdpr_documents_deleted":{
+      "examples":[
+        true
+      ],
+      "title":"GDPR Documents deleted",
+      "x-pii": false,
+      "type":["boolean","null"]
+    },
     "gender":{
       "examples":[
         "f"
@@ -2246,6 +2254,7 @@
         "vat_registered":"yes"
       },
       "first_hearing_date":"2012-12-12",
+      "gdpr_documents_deleted": true,
       "gender":"f",
       "has_disbursements":"no",
       "hearing_outcome":"CP03",


### PR DESCRIPTION
## Description of change

- [ ] https://github.com/ministryofjustice/laa-crime-application-store/pull/364

add optional `purged_docs` flag field for GDPR changes

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1792)

## Notes for reviewer

## How to manually test the feature
