### PR TITLE
CRM457-2444: NSM: QA Amended calculations removing rounding discrepancy

### DIFF
--- a/lib/laa_crime_forms_common/pricing/nsm/calculators/work_types.rb
+++ b/lib/laa_crime_forms_common/pricing/nsm/calculators/work_types.rb
@@ -25,15 +25,16 @@ module LaaCrimeFormsCommon
 
           def call
             calculations = work_items.map { Calculators::WorkItem.call(claim, _1, rates:) }
-
+            # rounded_types used for totals to ensure they're summed and rounded per work item type before totalling
+            rounded_types = [] 
             types = WORK_TYPES.to_h do |work_type|
               claimed_items = calculations.select { _1[:claimed_work_type] == work_type }
               assessed_items = calculations.select { _1[:assessed_work_type] == work_type }
-
-              [work_type.to_sym, build_summary(claimed_items, assessed_items)]
+              formatted_items = build_summary(claimed_items, assessed_items)
+              rounded_types << formatted_items
+              [work_type.to_sym, formatted_items]
             end
-
-            types[:total] = add_vat(build_summary(calculations))
+            types[:total] = add_vat(build_summary(rounded_types))
 
             types
           end

--- a/lib/laa_crime_forms_common/pricing/nsm/calculators/work_types.rb
+++ b/lib/laa_crime_forms_common/pricing/nsm/calculators/work_types.rb
@@ -34,7 +34,7 @@ module LaaCrimeFormsCommon
               rounded_types << formatted_items
               [work_type.to_sym, formatted_items]
             end
-            types[:total] = add_vat(build_summary(rounded_types))
+            types[:total] = add_vat(build_summary(calculations, calculations, rounded_types))
 
             types
           end
@@ -43,10 +43,14 @@ module LaaCrimeFormsCommon
             @work_items ||= claim.work_items.map { Wrappers::WorkItem.new(_1) }
           end
 
-          def build_summary(claimed_items, assessed_items = claimed_items)
-            claimed_total_exc_vat = claimed_items.sum(Rational(0, 1)) { _1[:claimed_total_exc_vat] }.round(2)
-            assessed_total_exc_vat = assessed_items.sum(Rational(0, 1)) { _1[:assessed_total_exc_vat] }.round(2)
-
+          def build_summary(claimed_items, assessed_items = claimed_items, summarized_items = nil)
+            if summarized_items.nil?
+              claimed_total_exc_vat = claimed_items.sum(Rational(0, 1)) { _1[:claimed_total_exc_vat] }.round(2)
+              assessed_total_exc_vat = assessed_items.sum(Rational(0, 1)) { _1[:assessed_total_exc_vat] }.round(2)
+            else
+              claimed_total_exc_vat = summarized_items.sum(Rational(0, 1)) { _1[:claimed_total_exc_vat] }.round(2)
+              assessed_total_exc_vat = summarized_items.sum(Rational(0, 1)) { _1[:assessed_total_exc_vat] }.round(2)
+            end
             {
               claimed_time_spent_in_minutes: claimed_items.sum(Rational(0, 1)) { _1[:claimed_time_spent_in_minutes] },
               claimed_total_exc_vat:,

--- a/lib/laa_crime_forms_common/pricing/nsm/calculators/work_types.rb
+++ b/lib/laa_crime_forms_common/pricing/nsm/calculators/work_types.rb
@@ -26,7 +26,7 @@ module LaaCrimeFormsCommon
           def call
             calculations = work_items.map { Calculators::WorkItem.call(claim, _1, rates:) }
             # rounded_types used for totals to ensure they're summed and rounded per work item type before totalling
-            rounded_types = [] 
+            rounded_types = []
             types = WORK_TYPES.to_h do |work_type|
               claimed_items = calculations.select { _1[:claimed_work_type] == work_type }
               assessed_items = calculations.select { _1[:assessed_work_type] == work_type }

--- a/lib/laa_crime_forms_common/version.rb
+++ b/lib/laa_crime_forms_common/version.rb
@@ -1,3 +1,3 @@
 module LaaCrimeFormsCommon
-  VERSION = "0.10.0".freeze
+  VERSION = "0.10.1".freeze
 end

--- a/spec/pricing/nsm_spec.rb
+++ b/spec/pricing/nsm_spec.rb
@@ -754,7 +754,7 @@ RSpec.describe LaaCrimeFormsCommon::Pricing::Nsm do
         end
 
         it "applies calculates the expected work_items totals" do
-          expect(described_class.totals(claim)[:work_types][:total][:claimed_total_inc_vat]).to eq(1205.01)
+          expect(described_class.totals(claim)[:work_types][:total][:claimed_total_inc_vat]).to eq(1205.02)
         end
       end
 


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2444)

- Group and round work item type totals before adding to overall total in work type calculator 
- Increment version

## Notes for reviewer

## How to manually test the feature
[Example of how to create discrepency here](https://coconut-halibut-07b.notion.site/Work-Item-Rounding-Example-1d6a3b77972880b19454fc39c50ea832?pvs=74)
