### PR TITLE
[CRM457-2627] send_back expired submissions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    laa_crime_forms_common (0.9.2)
+    laa_crime_forms_common (0.10.2)
+      activesupport
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)

--- a/laa_crime_forms_common.gemspec
+++ b/laa_crime_forms_common.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
     Dir["{config,lib}/**/*", "LICENSE", "README.md"]
   end
 
+  spec.add_dependency("activesupport")
   spec.add_dependency("httparty", ">= 0.22.0", "< 1")
   spec.add_dependency("i18n", ">= 1.8.11", "< 2")
   spec.add_dependency("json-schema", ">= 5.0.0", "< 6")

--- a/lib/laa_crime_forms_common.rb
+++ b/lib/laa_crime_forms_common.rb
@@ -8,6 +8,7 @@ require "laa_crime_forms_common/messages/prior_authority"
 require "laa_crime_forms_common/pricing/nsm"
 require "laa_crime_forms_common/s3_files"
 require "laa_crime_forms_common/validator"
+require "laa_crime_forms_common/working_day_service"
 
 mydir = __dir__
 I18n.load_path += Dir[File.join(mydir, "locales", "**/*.yml")]

--- a/lib/laa_crime_forms_common/version.rb
+++ b/lib/laa_crime_forms_common/version.rb
@@ -1,3 +1,3 @@
 module LaaCrimeFormsCommon
-  VERSION = "0.10.1".freeze
+  VERSION = "0.10.2".freeze
 end

--- a/lib/laa_crime_forms_common/working_day_service.rb
+++ b/lib/laa_crime_forms_common/working_day_service.rb
@@ -1,0 +1,25 @@
+require "active_support/core_ext/string"
+
+module LaaCrimeFormsCommon
+  class WorkingDayService
+    BANK_HOLIDAY_URL = "https://www.gov.uk/bank-holidays.json".freeze
+    class << self
+      def call(days)
+        chosen_date = Time.current
+        days_increased = 0
+        bank_holidays = retrieve_bank_holiday_list
+        while days_increased < days
+          chosen_date = chosen_date.next_weekday
+          days_increased += 1 unless chosen_date.to_date.in?(bank_holidays)
+        end
+
+        chosen_date
+      end
+
+      def retrieve_bank_holiday_list
+        response = HTTParty.get("https://www.gov.uk/bank-holidays.json")
+        response["england-and-wales"]["events"].map { _1["date"].to_date }
+      end
+    end
+  end
+end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,10 @@
+require "active_support"
+require "active_support/testing/time_helpers"
+require "active_support/core_ext/date_time"
+require "active_support/core_ext/numeric"
+
+ActiveSupport.to_time_preserves_timezone = :zone
+
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end

--- a/spec/working_day_service_spec.rb
+++ b/spec/working_day_service_spec.rb
@@ -1,0 +1,56 @@
+require_relative "../lib/laa_crime_forms_common/working_day_service"
+require "spec_helper"
+require "support/time_helpers"
+
+RSpec.describe LaaCrimeFormsCommon::WorkingDayService do
+  subject { described_class.call(days_to_increment) }
+
+  before do
+    travel_to date_to_test
+    stub_request(:get, "https://www.gov.uk/bank-holidays.json").to_return(
+      status: 200,
+      body: bank_holiday_list.to_json,
+      headers: { "Content-type" => "application/json" },
+    )
+  end
+
+  let(:bank_holiday_list) do
+    {
+      'england-and-wales': {
+        events: [
+          { date: "2024-01-01" },
+        ],
+      },
+    }
+  end
+
+  let(:a_september_tuesday) { Time.new(2024, 9, 24, 12, 23, 0) }
+  let(:a_september_thursday) { Time.new(2024, 9, 26, 12, 23, 0) }
+  let(:friday_29_december) { Time.new(2023, 12, 29, 12, 23, 0) }
+
+  let(:days_to_increment) { 2 }
+
+  context "when no weekends or bank holidays are involved" do
+    let(:date_to_test) { a_september_tuesday }
+
+    it "skips forward the number of days specified" do
+      expect(subject).to eq 2.days.from_now
+    end
+  end
+
+  context "when navigating a weekend" do
+    let(:date_to_test) { a_september_thursday }
+
+    it "skips forward the number of working days specified" do
+      expect(subject).to eq 4.days.from_now
+    end
+  end
+
+  context "when navigating a bank holiday and weekends" do
+    let(:date_to_test) { friday_29_december }
+
+    it "skips weekends and bank holidays" do
+      expect(subject).to eq 5.days.from_now
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2627)

required by app-store rake task to send_back expired submission and reset resubmission deadline date 

moving working_day_service into `common` as can be used between services

## Notes for reviewer

## How to manually test the feature
