### PR TITLE
CRM2680: add custom validators and types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)
+      uuid (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
@@ -64,6 +65,8 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
@@ -167,12 +170,15 @@ GEM
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
+    systemu (2.6.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uri (1.0.3)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
     webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/laa_crime_forms_common.gemspec
+++ b/laa_crime_forms_common.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("httparty", ">= 0.22.0", "< 1")
   spec.add_dependency("i18n", ">= 1.8.11", "< 2")
   spec.add_dependency("json-schema", ">= 5.0.0", "< 6")
-
+  spec.add_dependency("uuid", "~> 2.3")
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/laa_crime_forms_common.rb
+++ b/lib/laa_crime_forms_common.rb
@@ -9,6 +9,8 @@ require "laa_crime_forms_common/pricing/nsm"
 require "laa_crime_forms_common/s3_files"
 require "laa_crime_forms_common/validator"
 require "laa_crime_forms_common/working_day_service"
+Dir["#{File.join(__dir__, './laa_crime_forms_common/attributes/type')}/*.rb"].each { |f| require f }
+Dir["#{File.join(__dir__, './laa_crime_forms_common/validators')}/*.rb"].each { |f| require f }
 
 mydir = __dir__
 I18n.load_path += Dir[File.join(mydir, "locales", "**/*.yml")]

--- a/lib/laa_crime_forms_common/attributes/integer_time_period.rb
+++ b/lib/laa_crime_forms_common/attributes/integer_time_period.rb
@@ -1,0 +1,17 @@
+module LaaCrimeFormsCommon
+  class IntegerTimePeriod < SimpleDelegator
+    delegate :nil?, to: :__getobj__
+
+    def hours
+      return nil if __getobj__.nil?
+
+      __getobj__ / 60
+    end
+
+    def minutes
+      return nil if __getobj__.nil?
+
+      __getobj__ % 60
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/translation_object.rb
+++ b/lib/laa_crime_forms_common/attributes/translation_object.rb
@@ -1,0 +1,24 @@
+module LaaCrimeFormsCommon
+  class TranslationObject
+    attr_reader :value, :scope
+
+    delegate :to_s, :blank?, to: :translated
+
+    def initialize(value, scope)
+      @value = value
+      @scope = scope
+    end
+
+    def ==(other)
+      other.value == value && other.scope == scope
+    end
+    alias === ==
+    alias eql? ==
+
+    def translated
+      return '' unless value
+
+      I18n.t("laa_crime_forms_common.#{scope}.#{value}")
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/fully_validatable_decimal.rb
+++ b/lib/laa_crime_forms_common/attributes/type/fully_validatable_decimal.rb
@@ -1,0 +1,32 @@
+module LaaCrimeFormsCommon
+  module Type
+    class FullyValidatableDecimal < ActiveModel::Type::Decimal
+      def cast(value)
+        if check_valid(value)
+          super(remove_commas(value))
+        else
+          # If the user has entered a string that is not straightforwardly parseable
+          # as an integer, retain the original value so we can display it back to the user
+          value
+        end
+      end
+
+      private
+
+      def remove_commas(value)
+        value&.to_s&.delete(',')
+      end
+
+      def check_valid(value)
+        checks = [
+          value.is_a?(Integer),
+          value.is_a?(Float),
+          value.blank?,
+          Float(remove_commas(value), exception: false),
+          Integer(remove_commas(value), exception: false)
+        ]
+        (checks - [nil, false]).present?
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/fully_validatable_integer.rb
+++ b/lib/laa_crime_forms_common/attributes/type/fully_validatable_integer.rb
@@ -1,0 +1,15 @@
+module LaaCrimeFormsCommon
+  module Type
+    class FullyValidatableInteger < ActiveModel::Type::Integer
+      def cast(value)
+        if value.is_a?(Integer) || value.blank? || value.strip.gsub(/[0-9,-]/, '').empty?
+          super(value&.to_s&.delete(','))
+        else
+          # If the user has entered a string that is not straightforwardly parseable
+          # as an integer, retain the original value so we can display it back to the user
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/gbp.rb
+++ b/lib/laa_crime_forms_common/attributes/type/gbp.rb
@@ -1,0 +1,22 @@
+module LaaCrimeFormsCommon
+  module Type
+    class Gbp < ActiveModel::Type::Decimal
+      def cast(value)
+        if suitable_for_casting?(value)
+          # When a monetary value is provided by a form submission, we are only interested
+          # in the value to 2 decimal places, and discard any more fine detail immediately
+          with_extraneous_removed = value.to_s.delete(',').delete('£') if value
+          super(with_extraneous_removed)&.round(2)
+        else
+          # If the user has entered a string that is not straightforwardly parseable
+          # as an integer, retain the original value so we can display it back to the user
+          value
+        end
+      end
+
+      def suitable_for_casting?(value)
+        value.is_a?(Numeric) || value.blank? || value.strip.gsub(/[0-9,.£-]/, '').empty?
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/multiparam_date.rb
+++ b/lib/laa_crime_forms_common/attributes/type/multiparam_date.rb
@@ -1,0 +1,34 @@
+module LaaCrimeFormsCommon
+  module Type
+    class MultiparamDate < ActiveModel::Type::Date
+      # Used to coerce a Rails multi parameter date into a standard date,
+      # with some light validation to not end up with wrong dates or
+      # raising exceptions. Additional validation is performed in the
+      # form object through the validators.
+      #
+      def cast(value)
+        return value if value.blank? || value.is_a?(Date)
+
+        # `value` is a hash in the format: {3=>31, 2=>12, 1=>2000}
+        # where `3` is the day, `2` is the month and `1` is the year.
+        value_args = value.values_at(1, 2, 3).map { _1&.to_i }
+
+        if Date.valid_date?(*value_args) && value_args.none?(&:zero?)
+          Date.new(*value_args)
+        else
+          # This is not a valid date, but we return the hash so we perform
+          # more granular validation in the form object and can render the
+          # view with the errors and whatever values the user entered.
+          value
+        end
+      end
+
+      # Override superclass behavior as it will blindly try to build
+      # a date, which will blow up with wrong data (like day=32 or month=13).
+      # Leave the sanity check to the `#cast` method.
+      def value_from_multiparameter_assignment(value)
+        value
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/possibly_translated_array.rb
+++ b/lib/laa_crime_forms_common/attributes/type/possibly_translated_array.rb
@@ -1,0 +1,15 @@
+module LaaCrimeFormsCommon
+  module Type
+    class PossiblyTranslatedArray < ActiveModel::Type::Value
+      # This is for attributes where eeach will either be of format "x"
+      # or of format { "en" => "Some string", "value" => "x" }
+      def cast(values)
+        mapped = values&.map do |value|
+          value.is_a?(String) ? value : value['value']
+        end
+
+        super(mapped)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/possibly_translated_string.rb
+++ b/lib/laa_crime_forms_common/attributes/type/possibly_translated_string.rb
@@ -1,0 +1,11 @@
+module LaaCrimeFormsCommon
+  module Type
+    class PossiblyTranslatedString < ActiveModel::Type::String
+      # This is for attributes that will either be of format "x"
+      # or of format { "en" => "Some string", "value" => "x" }
+      def cast(value)
+        value.is_a?(Hash) ? super(value['value']) : super
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/stripped_string.rb
+++ b/lib/laa_crime_forms_common/attributes/type/stripped_string.rb
@@ -1,0 +1,12 @@
+module LaaCrimeFormsCommon
+  module Type
+    class StrippedString < ActiveModel::Type::String
+      # Remove leading and trailing spaces from strings, as these
+      # are usually obtained from input text and users can copy&paste
+      # introducing extraneous spaces without noticing.
+      def cast(value)
+        value.is_a?(String) ? super(value.strip) : super
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/time_period.rb
+++ b/lib/laa_crime_forms_common/attributes/type/time_period.rb
@@ -1,0 +1,39 @@
+module LaaCrimeFormsCommon
+  module Type
+    class TimePeriod < ActiveModel::Type::Integer
+      # Used to coerce a Rails multi parameter period into a integer,
+      # with some light validation to ensure all fields are entered.
+      # Additional validation is performed in the form object through
+      # the validators.
+      def cast(value)
+        if value.is_a?(Hash)
+          # extract hours and minutes from hash
+          hours, minutes = value.values_at(1, 2)
+          if valid_period?(hours, minutes)
+            # convert hours and minutes into
+            IntegerTimePeriod.new((hours.to_i * 60) + minutes.to_i)
+          else
+            # This is not a valid period, but we return the hash so we perform
+            # more granular validation in the form object and can render the
+            # view with the errors and whatever values the user entered.
+            value
+          end
+        else
+          # we should only get here when value is retrieved from the DB as an
+          # integer. As such we don't add any additional checks at this stage
+          # and would except the system to error if a non integer value is used.
+          IntegerTimePeriod.new(value)
+        end
+      end
+
+      def serialize(value)
+        value
+      end
+
+      def valid_period?(hours, minutes)
+        hours.to_s =~ /\A\d+\z/ && hours.to_i >= 0 &&
+          minutes.to_s =~ /\A\d+\z/ && (0..59).cover?(minutes.to_i)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/translated_object.rb
+++ b/lib/laa_crime_forms_common/attributes/type/translated_object.rb
@@ -1,0 +1,21 @@
+module LaaCrimeFormsCommon
+  module Type
+    class TranslatedObject < ActiveModel::Type::Value
+      def initialize(*args, **kwargs)
+        @scope = kwargs.delete(:scope)
+        super
+      end
+
+      def type
+        :translated
+      end
+
+      private
+
+      def cast_value(value)
+        key = value.is_a?(Hash) ? value['value'] : value
+        TranslationObject.new(key, @scope)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/translated_object_array.rb
+++ b/lib/laa_crime_forms_common/attributes/type/translated_object_array.rb
@@ -1,0 +1,15 @@
+module LaaCrimeFormsCommon
+  module Type
+    class TranslatedObjectArray < Type::TranslatedObject
+      def type
+        :translated_array
+      end
+
+      private
+
+      def cast_value(values)
+        values.map { super(_1) }
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/attributes/type/value_object.rb
+++ b/lib/laa_crime_forms_common/attributes/type/value_object.rb
@@ -1,0 +1,40 @@
+module LaaCrimeFormsCommon
+  module Type
+    class ValueObject < ActiveModel::Type::Value
+      attr_reader :source
+
+      def initialize(*args, **kwargs)
+        @source = kwargs.delete(:source)
+        super
+      end
+
+      def type
+        :value_object
+      end
+
+      def serialize(value)
+        value.to_s
+      end
+
+      def ==(other)
+        self.class == other.class && source == other.source
+      end
+      alias eql? ==
+
+      def hash
+        [self.class, source].hash
+      end
+
+      private
+
+      def cast_value(value)
+        case value
+        when String, Symbol
+          source.new(value)
+        when source
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/adjustments_dependant_validator.rb
+++ b/lib/laa_crime_forms_common/validators/adjustments_dependant_validator.rb
@@ -1,0 +1,26 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class AdjustmentsDependantValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        direction = record.claim.adjustments_direction
+
+        if value == Claim::GRANTED
+          validate_granted(record, attribute, direction)
+        elsif value == Claim::PART_GRANT
+          validate_part_grant(record, attribute, direction)
+        end
+      end
+
+      private
+
+      def validate_granted(record, attribute, direction)
+        record.errors.add(attribute, :'invalid.granted_with_reductions') if direction.in?([:mixed, :down])
+      end
+
+      def validate_part_grant(record, attribute, direction)
+        record.errors.add(attribute, :'invalid.part_granted_without_changes') if direction == :none
+        record.errors.add(attribute, :'invalid.part_granted_with_increases') if direction == :up
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/cost_item_type_dependant_validator.rb
+++ b/lib/laa_crime_forms_common/validators/cost_item_type_dependant_validator.rb
@@ -1,0 +1,18 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class CostItemTypeDependantValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        cost_item_type = cost_item_type_for(record)
+        cost_type_translated = I18n.t("prior_authority.service_costs.cost_fields.#{cost_item_type}")
+
+        record.errors.add(attribute, :blank, item_type: cost_type_translated) if value.blank?
+        record.errors.add(attribute, :not_a_number, item_type: cost_type_translated) if value.is_a?(String)
+        record.errors.add(attribute, :greater_than, item_type: cost_type_translated) unless value.to_d.positive?
+      end
+
+      def cost_item_type_for(record)
+        record.respond_to?(:cost_item_type) ? record.cost_item_type || 'item' : 'item'
+      end
+    end
+  end 
+end

--- a/lib/laa_crime_forms_common/validators/email_format_validator.rb
+++ b/lib/laa_crime_forms_common/validators/email_format_validator.rb
@@ -1,0 +1,48 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class EmailFormatValidator < ActiveModel::EachValidator
+      # This validation logic is copied from
+      # https://github.com/alphagov/notifications-utils/blob/main/notifications_utils/recipient_validation/email_address.py
+      # Because that logic is applied by Notify, and any email that Notify thinks is invalid will be rejected
+      # synchronously when we try to send an email. So we need to catch anything Notify thinks is invalid at the point
+      # of entry by a user
+      HOST_NAME_PATTERN = /\A(xn|[a-z0-9]+)(-?[a-z0-9]+)*\z/i
+      TLD_PATTERN = /\A([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)\z/i
+      EMAIL_REGEX_PATTERN = %r{\A(?!.*\.$)(?!^\.)[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@([^.@][^@\s]+)\z}
+      MAX_LENGTH = 320
+      MAX_HOST_NAME_LENGTH = 253
+      MIN_HOST_NAME_PARTS = 2
+      MAX_HOST_PART_LENGTH = 63
+      DOUBLE_DOT = '..'.freeze
+
+      def validate_each(record, attribute, value)
+        return if value.blank?
+
+        match = value.scan(EMAIL_REGEX_PATTERN)
+
+        return add_error(record, attribute) if match.blank?
+        return add_error(record, attribute) if value.length > MAX_LENGTH
+        return add_error(record, attribute) if value.include?(DOUBLE_DOT)
+
+        host_name = match[0][0]
+        validate_host_name(record, attribute, host_name)
+      end
+
+      def validate_host_name(record, attribute, host_name)
+        host_parts = host_name.split('.')
+
+        return add_error(record, attribute) if host_name.length > MAX_HOST_NAME_LENGTH || host_parts.length < MIN_HOST_NAME_PARTS
+
+        host_parts.each do |part|
+          return add_error(record, attribute) if part.blank? || part.length > MAX_HOST_PART_LENGTH || !HOST_NAME_PATTERN.match?(part)
+        end
+
+        add_error(record, attribute) unless TLD_PATTERN.match?(host_parts.last)
+      end
+
+      def add_error(record, attribute)
+        record.errors.add(attribute, :invalid)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/is_a_date_validator.rb
+++ b/lib/laa_crime_forms_common/validators/is_a_date_validator.rb
@@ -1,0 +1,24 @@
+# Can be used in combination with a form string attribute used to hold a date input value.
+# Useful in combination with MoJ date picker.
+# https://design-patterns.service.justice.gov.uk/components/date-picker/
+#
+# example:
+#  attribute :dob, :string
+#  validates :dob, is_a_date: true
+#
+# Any dates that are unparseable will be left as strings so that the user can
+# be shown exactly what they entered in the relevant field alongside the validation message.
+#
+module LaaCrimeFormsCommon
+  module Validators
+    class IsADateValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        return true if value.is_a?(Date) || value.blank?
+
+        Date.parse(value)
+      rescue Date::Error
+        record.errors.add(attribute, :not_a_date)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/is_a_number_validator.rb
+++ b/lib/laa_crime_forms_common/validators/is_a_number_validator.rb
@@ -1,0 +1,15 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class IsANumberValidator < ActiveModel::EachValidator
+      # For the custom types defined in config/initializers/attribute_types.rb,
+      # we will cast any values we recognise as numbers as numbers.
+      # Any numbers we don't recognise will be left as strings so that the user can
+      # be shown exactly what they entered in the relevant field alongside the validation message.
+      # This bit of logic notices any time a number has not been recognised, and ensures
+      # an appropriate validation message is shown.
+      def validate_each(record, attribute, value)
+        record.errors.add(attribute, :not_a_number) if value.is_a?(String)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/is_a_uuid_validator.rb
+++ b/lib/laa_crime_forms_common/validators/is_a_uuid_validator.rb
@@ -1,0 +1,11 @@
+require "uuid"
+
+module LaaCrimeFormsCommon
+  module Validators
+    class IsAUuidValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        record.errors.add attribute, (options[:message] || 'is not a valid uuid') unless UUID.validate(value)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/item_type_dependant_validator.rb
+++ b/lib/laa_crime_forms_common/validators/item_type_dependant_validator.rb
@@ -1,0 +1,18 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class ItemTypeDependantValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        item_type = item_type_for(record)
+
+        record.errors.add(attribute, :blank, item_type:) if value.blank?
+        record.errors.add(attribute, :not_a_number, item_type:) if value.is_a?(String)
+        record.errors.add(attribute, :greater_than, item_type:) if value.to_i.negative?
+      end
+
+      def item_type_for(record)
+        basic = record.respond_to?(:item_type) ? record.item_type || 'item' : 'item'
+        basic.pluralize
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/maat_validator.rb
+++ b/lib/laa_crime_forms_common/validators/maat_validator.rb
@@ -1,0 +1,18 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class MaatValidator < ActiveModel::EachValidator
+      attr_reader :record, :attribute
+
+      HARDCODED_VALUES = %w[4900900].freeze
+
+      def validate_each(record, attribute, value)
+        # this will trigger a `:blank` error when `presence: true`
+        return if value.blank?
+
+        return if HARDCODED_VALUES.include?(value) || value.match?(/\A\d{7}\z/)
+
+        record.errors.add(attribute, :invalid)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/multiparam_date_validator.rb
+++ b/lib/laa_crime_forms_common/validators/multiparam_date_validator.rb
@@ -1,0 +1,75 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class MultiparamDateValidator < ActiveModel::EachValidator
+      DATE_STRUCT = Struct.new('DateStruct', :day, :month, :year, keyword_init: true)
+
+      DEFAULT_OPTIONS = {
+        earliest_year: 1900,
+        latest_year: 2050,
+        allow_past: true,
+        allow_future: false,
+      }.freeze
+
+      attr_reader :record, :attribute, :config
+
+      def initialize(options)
+        super
+        @config = DEFAULT_OPTIONS.merge(options)
+      end
+
+      def validate_each(record, attribute, value)
+        # this will trigger a `:blank` error when `presence: true`
+        return if value.blank?
+
+        @record = record
+        @attribute = attribute
+
+        # If the value is a hash, we use a simple struct to keep a
+        # consistent interface, similar to a real date object.
+        # Remember, the hash will have the format: {3=>31, 2=>12, 1=>2000}
+        # where `3` is the day, `2` is the month and `1` is the year.
+        date = if value.is_a?(Hash)
+                DATE_STRUCT.new(day: value[3], month: value[2], year: value[1])
+              else
+                value
+              end
+
+        validate_date(date)
+      end
+
+      private
+
+      def validate_date(date)
+        add_error(:invalid_day)   unless date.day.to_i.between?(1, 31)
+        add_error(:invalid_month) unless date.month.to_i.between?(1, 12)
+        add_error(:invalid_year)  unless date.year.to_s.length.eql?(4)
+
+        if date.is_a?(Date)
+          validate_config_constraints(date)
+        else
+          # If, after all, we still don't have a valid date object, it means
+          # there are additional errors, like June 31st, or day 29 in non-leap year.
+          # We just add a generic error as it would be an overkill to set granular
+          # errors for all the possible combinations.
+          add_error(:invalid)
+        end
+      end
+
+      # Some basic constrains, for example some dates like DoB can't be in
+      # the future, or a date is very far in the past (potential user typo).
+      # This kind of validations can be configured passing an options hash
+      # when declaring the validation in the attribute.
+      def validate_config_constraints(date)
+        add_error(:past_not_allowed) unless config[:allow_past] || Time.zone.today <= date
+        add_error(:future_not_allowed) unless config[:allow_future] || Time.zone.today >= date
+
+        add_error(:year_too_late) if date.year > config[:latest_year]
+        add_error(:year_too_early) if date.year < config[:earliest_year]
+      end
+
+      def add_error(error)
+        record.errors.add(attribute, error)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/nested_validator.rb
+++ b/lib/laa_crime_forms_common/validators/nested_validator.rb
@@ -1,0 +1,56 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class NestedValidator < ActiveModel::EachValidator
+      def validate_each(object, attribute, value)
+        return unless value
+
+        was_array = value.is_a?(Array)
+
+        Array(value).each.with_index do |sub_record, index|
+          add_indexed_errors(object, attribute, was_array, sub_record, index) unless sub_record.valid?
+        end
+      end
+
+      private
+
+      def add_indexed_errors(object, attribute, was_array, sub_record, index)
+        sub_record.errors.each do |error|
+          attr_name = indexed_attribute(index, attribute, was_array, error.attribute)
+
+          object.errors.add(
+            attr_name,
+            error.type,
+            message: error_message(sub_record, error), name: error_message_name(object, index)
+          )
+
+          # We define the attribute getter as it doesn't really exist
+          object.define_singleton_method(attr_name) do
+            sub_record.public_send(error.attribute)
+          end
+        end
+      end
+
+      def indexed_attribute(index, attribute, was_array, attr)
+        return "#{attribute}-attributes[#{index}].#{attr}" if was_array
+
+        "#{attribute}-attributes.#{attr}"
+      end
+
+      # `activemodel.errors.models.steps/case/offence_date_fieldset_form.summary.x.y`
+      def error_message(obj, error)
+        I18n.t(
+          "#{obj.model_name.i18n_key}.summary.#{error.attribute}.#{error.type}",
+          scope: [:activemodel, :errors, :models]
+        )
+      end
+
+      def error_message_name(object, index)
+        if options[:name]
+          object.method(options[:name]).call(index)
+        else
+          index + 1
+        end
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/time_period_validator.rb
+++ b/lib/laa_crime_forms_common/validators/time_period_validator.rb
@@ -1,0 +1,82 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class TimePeriodValidator < ActiveModel::EachValidator
+      TIME_PERIOD_STRUCT = Struct.new('TIME_PERIOD_STRUCT', :hours, :minutes)
+
+      attr_reader :record, :attribute
+
+      def validate_each(record, attribute, value)
+        # this will trigger a `:blank` error when `presence: true`
+        return if value.blank?
+
+        @record = record
+        @attribute = attribute
+
+        # If the value is a hash, we use a simple struct to keep a
+        # consistent interface, similar to a real date object.
+        # Remember, the hash will have the format: {3=>31, 2=>12, 1=>2000}
+        # where `3` is the day, `2` is the month and `1` is the year.
+        time_period =
+          if value.is_a?(Hash)
+            TIME_PERIOD_STRUCT.new(hours: value[1], minutes: value[2])
+          else
+            value
+          end
+
+        validate_period(time_period)
+      end
+
+      private
+
+      def validate_period(time_period)
+        validate_hours(time_period.hours)
+        validate_minutes(time_period.minutes)
+
+        if time_period.is_a?(IntegerTimePeriod)
+          add_error(:zero_time_period) if time_period.to_i.zero? && !options[:allow_zero]
+          add_error(:invalid_period) unless time_period.to_i >= 0
+        else
+          # If, after all, we still don't have a valid date object, it means
+          # there are additional errors, like June 31st, or day 29 in non-leap year.
+          # We just add a generic error as it would be an overkill to set granular
+          # errors for all the possible combinations.
+          add_error(:invalid)
+        end
+      end
+
+      def validate_hours(hours)
+        add_error(:blank_hours) if hours.blank?
+        add_error(:non_numerical_hours) if non_numerical_string?(hours)
+        add_error(:non_integer_hours) if non_integer_string?(hours)
+        add_error(:invalid_hours) unless hours.to_i >= 0
+      end
+
+      def validate_minutes(minutes)
+        add_error(:blank_minutes) if minutes.blank?
+        add_error(:non_numerical_minutes) if non_numerical_string?(minutes)
+        add_error(:non_integer_minutes) if non_integer_string?(minutes)
+        add_error(:invalid_minutes) unless minutes.to_i.between?(0, 59)
+      end
+
+      def non_numerical_string?(value)
+        return false unless value.is_a?(String)
+
+        non_decimal_string?(value) && non_integer_string?(value)
+      end
+
+      def non_integer_string?(value)
+        return false unless value.is_a?(String)
+
+        value.strip.to_i.to_s != value.strip
+      end
+
+      def non_decimal_string?(value)
+        value.strip.to_f.to_s != value.strip
+      end
+
+      def add_error(error)
+        record.errors.add(attribute, error)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/ufn_validator.rb
+++ b/lib/laa_crime_forms_common/validators/ufn_validator.rb
@@ -1,0 +1,35 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class UfnValidator < ActiveModel::EachValidator
+      attr_reader :record, :attribute
+
+      def validate_each(record, attribute, value)
+        # this will trigger a `:blank` error when `presence: true`
+        return if value.blank?
+
+        @record = record
+        @attribute = attribute
+
+        matched, *date_parts_strings = *value.match(%r{\A(\d{2})(\d{2})(\d{2})/\d{3}\z})
+        date_parts = date_parts_strings.reverse.map(&:to_i)
+
+        if matched && Date.valid_date?(*date_parts)
+          # convert to 4 digit date
+          date_parts[0] += 2000
+
+          add_error :future_date if Date.new(*date_parts) > Time.zone.today
+        elsif value.match?(%r{[^\d/]})
+          add_error :invalid_characters
+        else
+          add_error :invalid
+        end
+      end
+
+      private
+
+      def add_error(error)
+        record.errors.add(attribute, error)
+      end
+    end
+  end
+end

--- a/lib/laa_crime_forms_common/validators/uk_postcode_validator.rb
+++ b/lib/laa_crime_forms_common/validators/uk_postcode_validator.rb
@@ -1,0 +1,25 @@
+module LaaCrimeFormsCommon
+  module Validators
+    class UkPostcodeValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        return if value.blank?
+
+        parsed = parse_postcode(value)
+
+        return if parsed.full_valid? || (options[:allow_partial] && valid_partial?(parsed, value))
+
+        record.errors.add(attribute, :invalid)
+      end
+
+      private
+
+      def parse_postcode(postcode)
+        UKPostcode.parse(postcode)
+      end
+
+      def valid_partial?(postcode, value)
+        postcode.valid? && postcode.outcode == value.strip.upcase
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2680)

## Notes for reviewer

- Add Custom Validators
- Add Custom Types
- Require them so they can be utilised in the gem


Note: autoloading validators is awkward so include LaaCrimeFormsCommon::Validators in the ApplicationRecord to use them
