### PR TITLE
CRM457-2999 : Update pipeline, pin actions to commit SHAs instead of versions

### DIFF
--- a/.github/workflows/test-opened-pr.yml
+++ b/.github/workflows/test-opened-pr.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code 
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       
       - name: Set up Ruby and install gems
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64
         with:
           bundler-cache: true
       
@@ -31,10 +31,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code 
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       
       - name: Set up Ruby and install gems
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64
         with:
           bundler-cache: true
       
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload code coverage results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: coverage-results
           path: coverage


### PR DESCRIPTION
## Description of change

Updated the pipeline to use commit SHAs instead of version numbers when pinning actions

[Link to ticket CRM457-2999](https://dsdmoj.atlassian.net/browse/CRM457-2999)

## Notes for reviewer
